### PR TITLE
Switch navbar-expand-md to navbar-expand-lg

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -28,7 +28,7 @@
   <body>
 
     <!-- Static navbar -->
-    <nav class="navbar navbar-expand-md navbar-dark" style="background-color: #052049">
+    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: #052049">
         <a class="navbar-brand" href="/">{{site.name}}</a>
         <a href="http://www.ucsf.edu"><img class="inline-block navb-icon" src="/static/img/ucsf_logo_white.svg"></a>
         <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Currently on medium layouts the expanded navbar gets cut off due to the new navbar items. This corrects that behavior.