### PR TITLE
Opt out of FLoC

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta name="description" content="{{ site.description }}">
     <meta name="theme-color" content="#052049">
+    <meta http-equiv="Permissions-Policy" content="interest-cohort=()"/>
     <link rel="stylesheet" href="/static/css/bootstrap.min.css">
     {% if page.group == 'news' %}
     <link rel="alternate" type="application/atom+xml" title="Fraser Lab News Feed" href="/news.xml">


### PR DESCRIPTION
Meta header to opt out of FLoC. 

More info: 
* https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea
* https://paramdeo.com/blog/opting-your-website-out-of-googles-floc-network